### PR TITLE
Add snyk monitoring [ATLAS-676]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,9 @@
 #!groovy
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-buildJavaLibraryOSSRH()
+withCredentials([string(credentialsId: 'snyk-wdk-token', variable: 'SNYK_TOKEN')])
+{
+    withEnv(['SNYK_ORG_NAME=wooga-pipeline', 'SNYK_AUTO_DOWNLOAD=YES']) {
+        buildJavaLibraryOSSRH()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,10 @@ plugins {
     id 'signing'
     id 'nebula.release' version '15.3.1'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.12.0'
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-wdk-java" version "0.3.0"
+    id "net.wooga.cve-dependency-resolution" version "0.3.0"
 }
 
 group "net.wooga.test"
@@ -39,13 +41,16 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.lingala.zip4j:zip4j:1.3.2'
-    implementation 'junit:junit:4.12'
-    implementation 'commons-io:commons-io:2.6'
+    implementation 'net.lingala.zip4j:zip4j:2.10.0'
+    implementation 'junit:junit:[4.12,5)'
+    implementation 'commons-io:commons-io:[2.6,3)'
 
-    testImplementation 'org.codehaus.groovy:groovy-all:2.4.15'
-    testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.codehaus.groovy:groovy-all:2.5.16'
+    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+}
+
+snyk {
+    projectTags = ["team": "atlas", "component": "library", "platform": "jvm", "language": "java"]
 }
 
 java {

--- a/src/main/java/net/wooga/test/unity/ProjectGeneratorRule.java
+++ b/src/main/java/net/wooga/test/unity/ProjectGeneratorRule.java
@@ -16,7 +16,7 @@
 
 package net.wooga.test.unity;
 
-import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import org.apache.commons.io.FileUtils;
 import org.junit.rules.ExternalResource;


### PR DESCRIPTION
## Description

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin `net.wooga.cve-dependency-resolution` which applies overrides for dependencies with know fixes for security issues.

Along with the introduction of snyk I also upgraded/removed some depdencies. Coveralls produces a huge load of errors even with the latest version so I decided to remove it since we want/are moving to sonarqube (It is unknown at this time if this dependency is actually better or not).

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin
* ![REMOVE] coveralls plugin
* ![UPDATE] `org.codehaus.groovy:groovy-all` to version `2.5.16`
* ![UPDATE] `net.lingala.zip4j:zip4j` to version `2.10.0`
* ![UPDATE] `commons-io:commons-io` to version `[2.5,3)`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
